### PR TITLE
Add excluded regions and EC2 filtering

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,11 +4,15 @@ resource "datadog_integration_aws" "core" {
   count      = var.enable_datadog_aws_integration ? 1 : 0
   account_id = var.aws_account_id
   role_name  = "datadog-integration-role"
+
   host_tags = [
     "Namespace:${var.namespace}",
     "env:${var.env}"
   ]
+
   account_specific_namespace_rules = var.account_specific_namespace_rules
+  excluded_regions                 = var.excluded_regions
+  filter_tags                      = var.filter_tags
 }
 
 resource "aws_iam_role" "datadog-integration" {

--- a/vars.tf
+++ b/vars.tf
@@ -68,3 +68,15 @@ variable "dd_forwarder_template_version" {
   type        = string
   default     = "3.13.0"
 }
+
+variable "excluded_regions" {
+  description = "An array of AWS regions to exclude from metrics collection"
+  type        = list(string)
+  default     = []
+}
+
+variable "filter_tags" {
+  description = "Array of EC2 tags (in the form key:value) defines a filter that Datadog use when collecting metrics from EC2. Wildcards, such as ? (for single characters) and * (for multiple characters) can also be used. Only hosts that match one of the defined tags will be imported into Datadog. The rest will be ignored."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
Add two new options to specify excluded regions for AWS integration and tags to filter out EC2 instances.