### PR TITLE
Add minimum version requirement for terraform and datadog

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    datadog = "~> 2.10"
+  }
+}


### PR DESCRIPTION
The recent change (https://github.com/scribd/terraform-aws-datadog/pull/10) requires a very recent datadog provider (2.10.0) which led to my pipeline failure at the `terraform plan` stage.

With this change, we can catch version mismatch at the `terraform init` stage, and makes the version requirement explicit to future users.

Reference: 

1. `excluded_regions` parameter was added in datadog provider version `2.10.0`: https://github.com/terraform-providers/terraform-provider-datadog/blob/master/CHANGELOG.md#2100-june-26-2020