### PR TITLE
feat(log forwarding): support DdSite option + upgrade default CF template version used

### DIFF
--- a/logs_monitoring.tf
+++ b/logs_monitoring.tf
@@ -5,6 +5,7 @@ resource aws_cloudformation_stack "datadog-forwarder" {
     DdApiKeySecretArn = aws_secretsmanager_secret.datadog_api_key.arn
     DdApiKey          = "dummy-value"
     DdTags            = "namespace:${var.namespace},env:${var.env}"
+    DdSite            = var.dd_forwarder_dd_site
     ExcludeAtMatch    = var.log_exclude_at_match
     FunctionName      = "${local.stack_prefix}datadog-forwarder"
   }

--- a/vars.tf
+++ b/vars.tf
@@ -66,7 +66,13 @@ variable "log_exclude_at_match" {
 variable "dd_forwarder_template_version" {
   description = "Sets Datadog Forwarder version to use"
   type        = string
-  default     = "3.13.0"
+  default     = "3.17.0"
+}
+
+variable "dd_forwarder_dd_site" {
+  type        = string
+  default     = "datadoghq.com"
+  description = "Define your Datadog Site to send data to. For the Datadog EU site, set to datadoghq.eu"
 }
 
 variable "excluded_regions" {


### PR DESCRIPTION
This PR adds new `dd_forwarder_dd_site` variable, to allow users to set `DdSite` parameter for datadog forwarder CF stack. Also CF stack version updated (no major changes there)