### PR TITLE
Add cloudtrail:LookupEvents IAM rights

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,6 +63,7 @@ resource "aws_iam_policy" "datadog-core" {
         "cloudfront:ListDistributions",
         "cloudtrail:DescribeTrails",
         "cloudtrail:GetTrailStatus",
+        "cloudtrail:LookupEvents",
         "cloudwatch:Describe*",
         "cloudwatch:Get*",
         "cloudwatch:List*",


### PR DESCRIPTION
To fix following error:
User:
arn:aws:sts::XYZ:assumed-role/datadog-integration-role/vault-app3.eu1.prod.dog-datadog-delancie-crawlerXYZ
is not authorized to perform: cloudtrail:LookupEvents