### PR TITLE
fix: make 0.12 minimum terraform cli version requirement so this module works with terraform version 0.13

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     datadog = "~> 2.10"

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12, < 0.14"
 
   required_providers {
-    datadog = "~> 2.10"
+    datadog = ">= 2.10, < 3"
   }
 }


### PR DESCRIPTION
#20 

I know there is this other PR that updates all the github actions to run using terraform version 0.13 but it has been open for a while: https://github.com/scribd/terraform-aws-datadog/pull/15

This is a simple fix that just allows us to use terraform version 0.13 with this module.