### PR TITLE
fix: use proper provider source for datadog

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.12, < 0.14"
 
   required_providers {
-    datadog = ">= 2.10, < 3"
+    datadog = {
+      source  = "DataDog/datadog"
+      version = ">= 2.10, < 3"
+    }
   }
 }


### PR DESCRIPTION
Missed this in the previous pull request: https://github.com/scribd/terraform-aws-datadog/pull/21
This is required for terraform version 0.13 to work
Closes #23  