### PR TITLE
feat: changes dd lambda default version from v3.17.0 to v3.27.0

### DIFF
--- a/vars.tf
+++ b/vars.tf
@@ -66,7 +66,7 @@ variable "log_exclude_at_match" {
 variable "dd_forwarder_template_version" {
   description = "Sets Datadog Forwarder version to use"
   type        = string
-  default     = "3.17.0"
+  default     = "3.27.0"
 }
 
 variable "dd_forwarder_dd_site" {


### PR DESCRIPTION
change the datadog lambda forwarder version from v3.17.0 to v3.27.0. There are many feature improvements in this version such as the support for SNS topic subscriptions for S3 bucket events