### PR TITLE
Adding cloudwatch:ListMetrics

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ resource "aws_iam_policy" "datadog-core" {
         "cloudtrail:DescribeTrails",
         "cloudtrail:GetTrailStatus",
         "cloudtrail:LookupEvents",
+        "cloudwatch:ListMetrics"
         "cloudwatch:Describe*",
         "cloudwatch:Get*",
         "cloudwatch:List*",

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_iam_policy" "datadog-core" {
         "cloudtrail:DescribeTrails",
         "cloudtrail:GetTrailStatus",
         "cloudtrail:LookupEvents",
-        "cloudwatch:ListMetrics"
+        "cloudwatch:ListMetrics",
         "cloudwatch:Describe*",
         "cloudwatch:Get*",
         "cloudwatch:List*",


### PR DESCRIPTION
I deployed the integration, the plan and apply have been success, however when I checked the integration page in the [Datadog Integrations Page](https://app.datadoghq.eu/account/settings#integrations/amazon-web-services)  I got the following screen:
![DD-AWS-Terrafrom-Integration-Error](https://user-images.githubusercontent.com/16150118/105491829-e6bad180-5cae-11eb-817b-faf65216c730.jpg)
After adding the cloudwatch:ListMetrics permission to the policy and redeployed the code, the issue has gone.