### PR TITLE
add fsx:DescribeFileSystems permission to role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,8 @@ resource "aws_iam_policy" "datadog-core" {
         "tag:GetTagKeys",
         "tag:GetTagValues",
         "xray:BatchGetTraces",
-        "xray:GetTraceSummaries"
+        "xray:GetTraceSummaries",
+        "fsx:DescribeFileSystems"
       ],
       "Effect": "Allow",
       "Resource": "*"


### PR DESCRIPTION
This PR adds the `fsx:DescribeFileSystems` permission to the datadog role, since we are seeing it attempting and failing in CloudTrail logs.