### PR TITLE
feat: enable support for Terraform 1.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13, < 0.15"
+  required_version = ">= 0.13, < 1.1.0"
 
   required_providers {
     datadog = {


### PR DESCRIPTION
Updating this module to work with Terraform versions up to, but not including, 1.1.

Tested this using both 0.15.3 and 1.0.2 deployments, both worked as expected.