### PR TITLE
feat: added states permissions to IAM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -120,6 +120,7 @@ resource "aws_iam_policy" "datadog-core" {
         "sns:List*",
         "sns:Publish",
         "states:ListStateMachines",
+        "states:DescribeStateMachine",
         "sqs:ListQueues",
         "support:*",
         "tag:GetResources",


### PR DESCRIPTION
Added `states:DescribeStateMachine` permission to the `aws_iam_policy` of `datadog-core`. This is a core step of [integrating with AWS Step Functions](https://docs.datadoghq.com/integrations/amazon_step_functions/).

Tested on forked branch and works as expected.