### PR TITLE
feat: enable support for Terraform 1.1.3

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13, < 1.1.0"
+  required_version = ">= 0.13, < 1.3.0"
 
   required_providers {
     datadog = {


### PR DESCRIPTION
Updating this module to work with Terraform versions up to, but not including, 1.3.0.