### PR TITLE
fix: explicitly specify the versions for semantic-release

### DIFF
--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -33,19 +33,18 @@ jobs:
       - run: terraform validate
 
   release:
-   if: github.event_name == 'push'
-   needs: terraform
-   runs-on: ubuntu-latest
-
-   steps:
-   - uses: actions/checkout@v2
-   - name: Semantic Release
-     id: semantic
-     uses: cycjimmy/semantic-release-action@v2
-     env:
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-     with:
-       semantic_version: 17
-       extra_plugins: |
-         @semantic-release/changelog
-         @semantic-release/git
+    if: github.event_name == 'push'
+    needs: terraform
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Semantic Release
+      id: semantic
+      uses: cycjimmy/semantic-release-action@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        semantic_version: 19
+        extra_plugins: |
+          @semantic-release/changelog@6
+          @semantic-release/git@10


### PR DESCRIPTION
fixes https://github.com/scribd/terraform-aws-datadog/issues/41

Somewhere along the way, the plugins below had a dependency requirement of semantic_release >=18:

```
npm WARN @semantic-release/git@10.0.1 requires a peer of semantic-release@>=18.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN @semantic-release/changelog@6.0.1 requires a peer of semantic-release@>=18.0.0 but none is installed. You must install peer dependencies yourself.
```

This PR pins the versions of sementic-release at the current release level. 