### PR TITLE
Use AWS Provider default tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [2.7.0](https://github.com/scribd/terraform-aws-datadog/compare/v2.6.0...v2.7.0) (2022-01-19)
+
+### Bug Fixes
+
+* **MAJOR BEHAVIORAL CHANGE**: Removing explicit tag declarations and enabling the default tags to be populated from the AWS provider. The intent is to enable the implementor
+  to use https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider instead of explicit declarations. 
+  The knock-on effect is that if you do not specify default tags in the AWS provider and you use this module your first plan will show all the existing
+  tags you have applied will be **shown as needing to be removed**. The fix here is to add the desired tags to the AWS provider 
+
+### Features
+
+* enable support for Terraform 1.1.3 ([#40](https://github.com/scribd/terraform-aws-datadog/issues/40)) ([51c5279](https://github.com/scribd/terraform-aws-datadog/commit/51c52792eed5f4b324420429677bbe9b10b0cef0))
+
+
 # [2.6.0](https://github.com/scribd/terraform-aws-datadog/compare/v2.5.0...v2.6.0) (2022-01-19)
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,8 +1,3 @@
 locals {
   stack_prefix = var.env == "" ? "" : "${join("-", compact([var.namespace, var.env]))}-"
-  default_tags = {
-    env       = var.env
-    namespace = var.namespace
-    terraform = "true"
-  }
 }

--- a/logs_monitoring.tf
+++ b/logs_monitoring.tf
@@ -21,7 +21,6 @@ resource "aws_cloudformation_stack" "datadog-forwarder" {
 resource "aws_secretsmanager_secret" "datadog_api_key" {
   name_prefix = "${local.stack_prefix}datadog-api-key"
   description = "Datadog API Key"
-  tags        = local.default_tags
 }
 
 resource "aws_secretsmanager_secret_version" "datadog_api_key" {

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,9 @@ resource "aws_iam_role" "datadog-integration" {
 }
 EOF
 
-  tags = merge(local.default_tags, {
+  tags = {
     description = "This role allows the datadog AWS account to access this account for metrics collection"
-  })
+  }
 }
 
 resource "aws_iam_policy" "datadog-core" {


### PR DESCRIPTION
The previous implementation had a set of tags applied to several resources using a merge function. This change allows the user of the module to specify their desired tags at the provider level.