### PR TITLE
feat: enable support for Datadog provider 3.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = ">= 2.10, < 3"
+      version = ">= 2.10, < 4"
     }
   }
 }


### PR DESCRIPTION
The only resource used from Datadog provider is "datadog_integration_aws" and it has not changed in any incompatible way between 2.x and 3.x versions. Relax the version requirement to allow 3.x versions of the provider.