### PR TITLE
fix: restrict aws provider to <4 for this major branch

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "DataDog/datadog"
       version = ">= 2.10, < 3"
     }
+
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.0, < 4"
+    }
   }
 }


### PR DESCRIPTION
v4 of the AWS provider introduced some breaking changes. We need to: 
- [x] maintain a working AWS v3 version of this module
- [ ] produce a new major version that is AWS v4 compatible. 

This PR addresses the former requirement. 

relates to https://github.com/scribd/terraform-aws-datadog/issues/43