### PR TITLE
feat!: enable support for aws provider 4.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Cloudwatch log sync are namspaced by module.
 
 ## Module Versions
 
+**Version 3.x.x** and greater require terraform version > 0.13.x and AWS provider > 4.0.0.
 **Version 2.x.x** and greater require terraform version > 0.13.x and AWS provider < 4.0.0.  
 **Version 1.x.x** is the latest version that support terraform version 0.12.x and AWS provider < 4.0.0.  
 When using this module, please be sure to [pin to a compatible version](https://www.terraform.io/docs/configuration/modules.html#module-versions).

--- a/versions.tf
+++ b/versions.tf
@@ -8,8 +8,8 @@ terraform {
     }
 
     aws = {
-      source = "hashicorp/aws"
-      version = ">= 3.0, < 4"
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
     }
   }
 }


### PR DESCRIPTION
This should fix https://github.com/scribd/terraform-aws-datadog/issues/43
**BREAKING CHANGE**
Based on the below understanding , I think we do not need to do manual import in most of the cases. However we should create a major version though. 

Each of the new aws_s3_bucket_* resources relies on S3 API calls that utilize a PUT action in order to modify the target S3 bucket. Because these API calls adhere to standard HTTP methods for REST APIs, they should handle situations where the target configuration already exists (as noted in the [HTTP RFC](https://datatracker.ietf.org/doc/html/rfc2616#section-9.6)). Given that this is the case, it's not strictly necessary to import any new aws_s3_bucket_* resources that are a one-to-one translation from previous versions of the AWS provider -- on the next terraform apply, they'll attempt the PUT, and update the state with the results as necessary. There is, however, a downside to this approach in that the diff will show each of the new resources as needing to be created.