### PR TITLE
feat: enable support for Terraform 1.3.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13, < 1.3.0"
+  required_version = ">= 0.13, < 1.4.0"
 
   required_providers {
     datadog = {


### PR DESCRIPTION
Using Terraform 1.3.2, this module seems to work just as expected, all resources created fine. I can see no breaking changes between tf 1.2 and 1.3 which should affect this. This will relax the requirements to allow any 1.3.x to be used.