### PR TITLE
Fix `statement_id` length

### DIFF
--- a/logs_monitoring_cloudwatch_log.tf
+++ b/logs_monitoring_cloudwatch_log.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
   count         = length(var.cloudwatch_log_groups)
-  statement_id  = "${substr(replace(var.cloudwatch_log_groups[count.index], "/", "_"), 0, 60)}-AllowExecutionFromCloudWatchLogs"
+  statement_id  = "${substr(replace(var.cloudwatch_log_groups[count.index], "/", "_"), 0, 67)}-AllowExecutionFromCloudWatchLogs"
   action        = "lambda:InvokeFunction"
   function_name = aws_cloudformation_stack.datadog-forwarder.outputs.DatadogForwarderArn
   principal     = "logs.${var.aws_region}.amazonaws.com"

--- a/logs_monitoring_cloudwatch_log.tf
+++ b/logs_monitoring_cloudwatch_log.tf
@@ -9,7 +9,7 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
   count         = length(var.cloudwatch_log_groups)
-  statement_id  = "${replace(var.cloudwatch_log_groups[count.index], "/", "_")}-AllowExecutionFromCloudWatchLogs"
+  statement_id  = "${substr(replace(var.cloudwatch_log_groups[count.index], "/", "_"), 0, 60)}-AllowExecutionFromCloudWatchLogs"
   action        = "lambda:InvokeFunction"
   function_name = aws_cloudformation_stack.datadog-forwarder.outputs.DatadogForwarderArn
   principal     = "logs.${var.aws_region}.amazonaws.com"


### PR DESCRIPTION
While typical statement_id is generated by terraform -- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission.html

if log-groups are too lengthy, this will cause issue where `statement_id` is more than 100 characters, refer - https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html#API_AddPermission_RequestSyntax
