### PR TITLE
Remove private ACL S3 terraform resource

### DIFF
--- a/logs_monitoring_elb.tf
+++ b/logs_monitoring_elb.tf
@@ -52,12 +52,6 @@ resource "aws_s3_bucket_policy" "elb_logs" {
   policy = data.aws_iam_policy_document.elb_logs.json
 }
 
-resource "aws_s3_bucket_acl" "elb_logs" {
-  count  = var.create_elb_logs_bucket ? 1 : 0
-  bucket = aws_s3_bucket.elb_logs[0].id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_lifecycle_configuration" "elb_logs" {
   count  = var.create_elb_logs_bucket ? 1 : 0
   bucket = aws_s3_bucket.elb_logs[0].id


### PR DESCRIPTION
Remove private ACL terraform resource. 
Broken since April, 2023 for creating new S3 buckets and specifying ACL's: 
https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/