### PR TITLE
Switch to for_each for log forwarding resources

### DIFF
--- a/logs_monitoring_cloudwatch_log.tf
+++ b/logs_monitoring_cloudwatch_log.tf
@@ -1,17 +1,17 @@
 resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
-  count           = length(var.cloudwatch_log_groups)
-  name            = "${var.cloudwatch_log_groups[count.index]}-filter"
-  log_group_name  = var.cloudwatch_log_groups[count.index]
+  for_each        = { for lg in var.cloudwatch_log_groups : lg => lg }
+  name            = "${each.value}-filter"
+  log_group_name  = each.value
   filter_pattern  = ""
   destination_arn = aws_cloudformation_stack.datadog-forwarder.outputs.DatadogForwarderArn
   distribution    = "Random"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
-  count         = length(var.cloudwatch_log_groups)
-  statement_id  = "${substr(replace(var.cloudwatch_log_groups[count.index], "/", "_"), 0, 67)}-AllowExecutionFromCloudWatchLogs"
+  for_each      = { for lg in var.cloudwatch_log_groups : lg => lg }
+  statement_id  = "${substr(replace(each.value, "/", "_"), 0, 67)}-AllowExecutionFromCloudWatchLogs"
   action        = "lambda:InvokeFunction"
   function_name = aws_cloudformation_stack.datadog-forwarder.outputs.DatadogForwarderArn
   principal     = "logs.${var.aws_region}.amazonaws.com"
-  source_arn    = "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:${var.cloudwatch_log_groups[count.index]}:*"
+  source_arn    = "arn:aws:logs:${var.aws_region}:${var.aws_account_id}:log-group:${each.value}:*"
 }


### PR DESCRIPTION
In case `var.cloudwatch_log_groups` changes somewhere in the middle of the list, all resources indexed since that position must be recreated. 
This can be remedied by switching to `for_each` instead of `count`

Was:
```
  # module.datadog[0].aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter[0] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
      + destination_arn = (known after apply)
      + distribution    = "Random"
      + id              = (known after apply)
      + log_group_name  = "/aws/sagemaker/TransformJobs"
      + name            = "/aws/sagemaker/TransformJobs-filter"
      + role_arn        = (known after apply)
    }

  # module.datadog[0].aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter[1] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
      + destination_arn = (known after apply)
      + distribution    = "Random"
      + id              = (known after apply)
      + log_group_name  = "/aws/sagemaker/Endpoints/slideshare-spam-model"
      + name            = "/aws/sagemaker/Endpoints/slideshare-spam-model-filter"
      + role_arn        = (known after apply)
    }

  # module.datadog[0].aws_lambda_permission.allow_cloudwatch_logs_to_call_dd_lambda_handler[0] will be created
  + resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
      + action              = "lambda:InvokeFunction"
      + function_name       = (known after apply)
      + id                  = (known after apply)
      + principal           = "logs.us-east-2.amazonaws.com"
      + source_arn          = "arn:aws:logs:us-east-2::log-group:/aws/sagemaker/TransformJobs:*"
      + statement_id        = "_aws_sagemaker_TransformJobs-AllowExecutionFromCloudWatchLogs"
      + statement_id_prefix = (known after apply)
    }

  # module.datadog[0].aws_lambda_permission.allow_cloudwatch_logs_to_call_dd_lambda_handler[1] will be created
  + resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
      + action              = "lambda:InvokeFunction"
      + function_name       = (known after apply)
      + id                  = (known after apply)
      + principal           = "logs.us-east-2.amazonaws.com"
      + source_arn          = "arn:aws:logs:us-east-2::log-group:/aws/sagemaker/Endpoints/slideshare-spam-model:*"
      + statement_id        = "_aws_sagemaker_Endpoints_slideshare-spam-model-AllowExecutionFromCloudWatchLogs"
      + statement_id_prefix = (known after apply)
    }
```

Is:
```
  # module.datadog[0].aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter["/aws/sagemaker/Endpoints/slideshare-spam-model"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
      + destination_arn = (known after apply)
      + distribution    = "Random"
      + id              = (known after apply)
      + log_group_name  = "/aws/sagemaker/Endpoints/slideshare-spam-model"
      + name            = "/aws/sagemaker/Endpoints/slideshare-spam-model-filter"
      + role_arn        = (known after apply)
    }

  # module.datadog[0].aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter["/aws/sagemaker/TransformJobs"] will be created
  + resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
      + destination_arn = (known after apply)
      + distribution    = "Random"
      + id              = (known after apply)
      + log_group_name  = "/aws/sagemaker/TransformJobs"
      + name            = "/aws/sagemaker/TransformJobs-filter"
      + role_arn        = (known after apply)
    }

  # module.datadog[0].aws_lambda_permission.allow_cloudwatch_logs_to_call_dd_lambda_handler["/aws/sagemaker/Endpoints/slideshare-spam-model"] will be created
  + resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
      + action              = "lambda:InvokeFunction"
      + function_name       = (known after apply)
      + id                  = (known after apply)
      + principal           = "logs.us-east-2.amazonaws.com"
      + source_arn          = "arn:aws:logs:us-east-2::log-group:/aws/sagemaker/Endpoints/slideshare-spam-model:*"
      + statement_id        = "_aws_sagemaker_Endpoints_slideshare-spam-model-AllowExecutionFromCloudWatchLogs"
      + statement_id_prefix = (known after apply)
    }

  # module.datadog[0].aws_lambda_permission.allow_cloudwatch_logs_to_call_dd_lambda_handler["/aws/sagemaker/TransformJobs"] will be created
  + resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
      + action              = "lambda:InvokeFunction"
      + function_name       = (known after apply)
      + id                  = (known after apply)
      + principal           = "logs.us-east-2.amazonaws.com"
      + source_arn          = "arn:aws:logs:us-east-2::log-group:/aws/sagemaker/TransformJobs:*"
      + statement_id        = "_aws_sagemaker_TransformJobs-AllowExecutionFromCloudWatchLogs"
      + statement_id_prefix = (known after apply)
    }

```