### PR TITLE
fix: Work around the limit in lambda policy size

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -5,4 +5,5 @@ locals {
     namespace = var.namespace
     terraform = "true"
   }
+  log_groups_to_use = length(var.log_group_prefixes) > 0 ? var.log_group_prefixes : var.cloudwatch_log_groups
 }

--- a/vars.tf
+++ b/vars.tf
@@ -37,6 +37,11 @@ variable "cloudwatch_log_groups" {
   type        = list(string)
   default     = []
 }
+variable "log_group_prefixes" {
+  description = "List of CloudWatch Log Group prefixes to create lambda permissions"
+  type        = list(string)
+  default     = []
+}
 variable "enable_datadog_aws_integration" {
   description = "Use datadog provider to give datadog aws account access to our resources"
   type        = bool


### PR DESCRIPTION
Currently failing with
```
│ Error: adding Lambda Permission (arn:aws:lambda:us-east-2:591234544403:function:model-inference-development-datadog-forwarder/_aws_sagemaker_Endpoints_recs-ranker-rn-scribd-has-read-after-AllowExecutionFromCloudWatchLogs): PolicyLengthExceededException: The final policy size (20782) is bigger than the limit (20480).
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "e220c7fb-c4c9-4b93-9f15-beba592a3afc"
│   },
│   Message_: "The final policy size (20782) is bigger than the limit (20480).",
│   Type: "User"
│ }
│
│   with module.datadog[0].aws_lambda_permission.allow_cloudwatch_logs_to_call_dd_lambda_handler["/aws/sagemaker/Endpoints/recs-ranker-rn-scribd-has-read-after"],
│   on .terraform/modules/datadog/logs_monitoring_cloudwatch_log.tf line 10, in resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler":
│   10: resource "aws_lambda_permission" "allow_cloudwatch_logs_to_call_dd_lambda_handler" {
}
```

Current size of lambda policy:
```
$ aws lambda get-policy --function-name model-inference-development-datadog-forwarder | jq -r '.Policy' | wc
       1       1   20090
```

Now we can pass array like `log_group_prefixes = ["/aws/sagemaker/Endpoints/", "/aws/sagemaker/TransformJobs"]` to force small size of the policy if necessary

Changes to the module are backward-compatible