### PR TITLE
COREINF-8724: add possibility to define lamdba mem

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module "datadog" {
   datadog_api_key       = var.datadog_api_key
   env                   = "prod"
   namespace             = "team_foo"
+  dd_forwarder_memory_size = 1024
 
   cloudtrail_bucket_id  = aws_s3_bucket.org-cloudtrail-bucket.id
   cloudtrail_bucket_arn = aws_s3_bucket.org-cloudtrail-bucket.arn
@@ -59,6 +60,7 @@ module "datadog" {
   enable_datadog_aws_integration = false
   env                            = "prod"
   namespace                      = "project_foo"
+  dd_forwarder_memory_size       = 1024
 
   cloudwatch_log_groups = ["cloudwatch_log_group_1", "cloudwatch_log_group_2"]
 }

--- a/logs_monitoring.tf
+++ b/logs_monitoring.tf
@@ -8,6 +8,7 @@ resource "aws_cloudformation_stack" "datadog-forwarder" {
     DdSite            = var.dd_forwarder_dd_site
     ExcludeAtMatch    = var.log_exclude_at_match
     FunctionName      = "${local.stack_prefix}datadog-forwarder"
+    MemorySize        = var.dd_forwarder_memory_size
   }
   template_url = "https://datadog-cloudformation-template.s3.amazonaws.com/aws/forwarder/${var.dd_forwarder_template_version}.yaml"
   tags         = merge(local.default_tags, var.tags)

--- a/vars.tf
+++ b/vars.tf
@@ -74,6 +74,12 @@ variable "dd_forwarder_template_version" {
   default     = "3.100.0"
 }
 
+variable "dd_forwarder_memory_size" {
+  description = "Memory size for the Datadog Forwarder Lambda function"
+  type        = number
+  default     = 1024
+}
+
 variable "dd_forwarder_dd_site" {
   type        = string
   default     = "datadoghq.com"


### PR DESCRIPTION
add possibility to define lamdba mem to use in other code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, backwards-compatible Terraform input that only affects forwarder Lambda sizing (default unchanged at 1024). Main risk is unintended resource updates if consumers change this value.
> 
> **Overview**
> Adds new module input `dd_forwarder_memory_size` (default `1024`) and passes it as the CloudFormation `MemorySize` parameter for the Datadog Forwarder Lambda.
> 
> Updates the README usage examples to document the new configuration knob.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1dae95893dc97b5faf335c5764af8ecf61ab7fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->