### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -37,7 +37,7 @@ jobs:
     needs: terraform
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
       uses: cycjimmy/semantic-release-action@v2


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v2` → `actions/checkout@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the GitHub Actions `checkout` action version in the release job, with no application/runtime code impact.
> 
> **Overview**
> Updates the `release` job in `.github/workflows/terraform_and_release.yml` to use `actions/checkout@v6` instead of the older `v2`, aligning the pipeline with newer GitHub Actions runtime requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9049126709fe9c0ab2334cb9ae999b7936e35fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->