### PR TITLE
Coreinf-8740: add support to terraform 1.5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13, < 1.4.0"
+  required_version = ">= 0.13"
 
   required_providers {
     datadog = {


### PR DESCRIPTION
This will relax constraint to terraform version

https://scribdjira.atlassian.net/browse/COREINF-8740

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes an `aws_s3_bucket_acl` resource and changes Lambda permission `statement_id` generation, which may cause Terraform plan/state changes in existing deployments. The Terraform version constraint relaxation is low risk but could expose compatibility issues on newer Terraform versions.
> 
> **Overview**
> Relaxes `terraform.required_version` by removing the `< 1.4.0` upper bound to allow newer Terraform releases.
> 
> Fixes AWS infrastructure edge cases by truncating CloudWatch Logs Lambda permission `statement_id` values to stay within AWS limits and by removing the explicit private `aws_s3_bucket_acl` for the ELB logs bucket. Updates `CHANGELOG.md` with these bugfix entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7eb513f4bf2a32b97accdedebaa43287d98fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->