### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -44,7 +44,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        semantic_version: 19
+        semantic_version: 24
         extra_plugins: |
           @semantic-release/changelog@6
           @semantic-release/git@10

--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v6
+      uses: cycjimmy/semantic-release-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -10,7 +10,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@master
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 0.13.x
 
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/terraform_and_release.yml
+++ b/.github/workflows/terraform_and_release.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Semantic Release
       id: semantic
-      uses: cycjimmy/semantic-release-action@v5
+      uses: cycjimmy/semantic-release-action@v6
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `cycjimmy/semantic-release-action@v2` → `cycjimmy/semantic-release-action@v5`
- `hashicorp/setup-terraform@v1` → `hashicorp/setup-terraform@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is workflow breakage if the new action major versions change defaults or inputs.
> 
> **Overview**
> Updates the CI workflow to use newer GitHub Action major versions: `hashicorp/setup-terraform` from `v1` to `v4`, and `cycjimmy/semantic-release-action` from `v2` to `v5`.
> 
> Bumps the configured `semantic_version` used by the release job from `19` to `24` to match the updated action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3522a1965913becdbe8276c2c2bbb9b683bb498c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->